### PR TITLE
feat: Complete blackboard decoration API

### DIFF
--- a/src/main/java/dev/line4/blackBoard/letter/controller/LetterController.java
+++ b/src/main/java/dev/line4/blackBoard/letter/controller/LetterController.java
@@ -1,7 +1,14 @@
 package dev.line4.blackBoard.letter.controller;
 
+import dev.line4.blackBoard.letter.dto.LetterReqDto;
+import dev.line4.blackBoard.letter.dto.LetterResDto;
 import dev.line4.blackBoard.letter.service.LetterServiceImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class LetterController {
 
     private final LetterServiceImpl letterService;
+
+    @PostMapping("letter/{blackboardId}")
+    public ResponseEntity<?> createLetter(@RequestBody LetterReqDto dto, @PathVariable String blackboardId) {
+        LetterResDto result = letterService.createLetter(dto, blackboardId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+
 }

--- a/src/main/java/dev/line4/blackBoard/letter/dto/LetterReqDto.java
+++ b/src/main/java/dev/line4/blackBoard/letter/dto/LetterReqDto.java
@@ -1,5 +1,7 @@
 package dev.line4.blackBoard.letter.dto;
 
+import dev.line4.blackBoard.lettersticker.dto.LetterStickerReqDto;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,4 +10,9 @@ import lombok.Setter;
 @Getter
 @Setter
 public class LetterReqDto {
+    private String nickname;
+    private String content;
+    private String font;
+    private String align;
+    private List<LetterStickerReqDto> stickers;
 }

--- a/src/main/java/dev/line4/blackBoard/letter/dto/LetterResDto.java
+++ b/src/main/java/dev/line4/blackBoard/letter/dto/LetterResDto.java
@@ -8,4 +8,5 @@ import lombok.Setter;
 @Getter
 @Setter
 public class LetterResDto {
+    private String url;
 }

--- a/src/main/java/dev/line4/blackBoard/letter/entity/Letters.java
+++ b/src/main/java/dev/line4/blackBoard/letter/entity/Letters.java
@@ -40,7 +40,10 @@ public class Letters {
     private String nickname;
 
     @Column(name = "font")
-    private Long font;
+    private String font;
+
+    @Column(name = "align")
+    private String align;
 
     // black_board_id (FK) 추후에 추가
 
@@ -59,12 +62,12 @@ public class Letters {
         Letters letters = (Letters) o;
         return Objects.equals(letterId, letters.letterId) && Objects.equals(content, letters.content)
                 && Objects.equals(nickname, letters.nickname) && Objects.equals(font, letters.font)
-                && Objects.equals(stickers, letters.stickers);
+                && Objects.equals(align, letters.align) && Objects.equals(stickers, letters.stickers);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(letterId, content, nickname, font, stickers);
+        return Objects.hash(letterId, content, nickname, font, align, stickers);
     }
 
     @Override
@@ -73,9 +76,9 @@ public class Letters {
                 "letterId=" + letterId +
                 ", content='" + content + '\'' +
                 ", nickname='" + nickname + '\'' +
-                ", font=" + font +
+                ", font='" + font + '\'' +
+                ", align='" + align + '\'' +
                 ", stickers=" + stickers +
                 '}';
     }
-
 }

--- a/src/main/java/dev/line4/blackBoard/letter/repository/LetterRepository.java
+++ b/src/main/java/dev/line4/blackBoard/letter/repository/LetterRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LetterRepository extends JpaRepository<Long, Letters> {
+public interface LetterRepository extends JpaRepository<Letters, Long> {
 }

--- a/src/main/java/dev/line4/blackBoard/letter/service/LetterService.java
+++ b/src/main/java/dev/line4/blackBoard/letter/service/LetterService.java
@@ -1,4 +1,8 @@
 package dev.line4.blackBoard.letter.service;
 
+import dev.line4.blackBoard.letter.dto.LetterReqDto;
+import dev.line4.blackBoard.letter.dto.LetterResDto;
+
 public interface LetterService {
+    LetterResDto createLetter(LetterReqDto dto, String blackboardId);
 }

--- a/src/main/java/dev/line4/blackBoard/letter/service/LetterServiceImpl.java
+++ b/src/main/java/dev/line4/blackBoard/letter/service/LetterServiceImpl.java
@@ -1,7 +1,46 @@
 package dev.line4.blackBoard.letter.service;
 
+import dev.line4.blackBoard.letter.dto.LetterReqDto;
+import dev.line4.blackBoard.letter.dto.LetterResDto;
+import dev.line4.blackBoard.letter.entity.Letters;
+import dev.line4.blackBoard.letter.repository.LetterRepository;
+import dev.line4.blackBoard.lettersticker.service.LetterStickerServiceImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class LetterServiceImpl implements LetterService {
+
+    // 추후에 BlackBoardRepository 추가
+    private final LetterRepository letterRepository;
+    private final LetterStickerServiceImpl letterStickerService;
+
+    @Override
+    public LetterResDto createLetter(LetterReqDto dto, String blackboardId) {
+
+        // 추후에 blackboard 와 연관관계 작성
+
+        // Letter 빌드
+        Letters newLetter = Letters.builder()
+                .nickname(dto.getNickname())
+                .content(dto.getContent())
+                .font(dto.getFont())
+                .align(dto.getAlign())
+                .build();
+
+        // Letter 저장
+        Letters savedLetter = letterRepository.save(newLetter);
+
+        // LetterSticker 들 저장
+        letterStickerService.createLetterStickers(dto.getStickers(), savedLetter);
+
+        // 리턴값 (url) 빌드
+        LetterResDto resDto = LetterResDto.builder()
+                .url("임시값입니다. 실제로는 blackboardId, 즉 url 이 들어옵니다.")
+                .build();
+
+        return resDto;
+
+    }
 }

--- a/src/main/java/dev/line4/blackBoard/lettersticker/dto/LetterStickerReqDto.java
+++ b/src/main/java/dev/line4/blackBoard/lettersticker/dto/LetterStickerReqDto.java
@@ -1,0 +1,16 @@
+package dev.line4.blackBoard.lettersticker.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class LetterStickerReqDto {
+    private Long num;
+    private Double positionX;
+    private Double positionY;
+    private Long img;
+    private Double width;
+}

--- a/src/main/java/dev/line4/blackBoard/lettersticker/entity/LetterStickers.java
+++ b/src/main/java/dev/line4/blackBoard/lettersticker/entity/LetterStickers.java
@@ -84,5 +84,4 @@ public class LetterStickers {
                 ", letter=" + letter +
                 '}';
     }
-
 }

--- a/src/main/java/dev/line4/blackBoard/lettersticker/repository/LetterStickerRepository.java
+++ b/src/main/java/dev/line4/blackBoard/lettersticker/repository/LetterStickerRepository.java
@@ -1,0 +1,9 @@
+package dev.line4.blackBoard.lettersticker.repository;
+
+import dev.line4.blackBoard.lettersticker.entity.LetterStickers;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LetterStickerRepository extends JpaRepository<LetterStickers, Long> {
+}

--- a/src/main/java/dev/line4/blackBoard/lettersticker/service/LetterStickerService.java
+++ b/src/main/java/dev/line4/blackBoard/lettersticker/service/LetterStickerService.java
@@ -1,0 +1,9 @@
+package dev.line4.blackBoard.lettersticker.service;
+
+import dev.line4.blackBoard.letter.entity.Letters;
+import dev.line4.blackBoard.lettersticker.dto.LetterStickerReqDto;
+import java.util.List;
+
+public interface LetterStickerService {
+    void createLetterStickers(List<LetterStickerReqDto> stickerDtoList, Letters letter);
+}

--- a/src/main/java/dev/line4/blackBoard/lettersticker/service/LetterStickerServiceImpl.java
+++ b/src/main/java/dev/line4/blackBoard/lettersticker/service/LetterStickerServiceImpl.java
@@ -1,0 +1,32 @@
+package dev.line4.blackBoard.lettersticker.service;
+
+import dev.line4.blackBoard.letter.entity.Letters;
+import dev.line4.blackBoard.lettersticker.dto.LetterStickerReqDto;
+import dev.line4.blackBoard.lettersticker.entity.LetterStickers;
+import dev.line4.blackBoard.lettersticker.repository.LetterStickerRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LetterStickerServiceImpl implements LetterStickerService {
+
+    private final LetterStickerRepository letterStickerRepository;
+
+    @Override
+    public void createLetterStickers(List<LetterStickerReqDto> stickerDtoList, Letters letter) {
+        for (LetterStickerReqDto stickerDto : stickerDtoList) {
+            LetterStickers sticker = LetterStickers.builder()
+                    .num(stickerDto.getNum())
+                    .positionX(stickerDto.getPositionX())
+                    .positionY(stickerDto.getPositionY())
+                    .img(stickerDto.getImg())
+                    .width(stickerDto.getWidth())
+                    .letter(letter)
+                    .build();
+            letterStickerRepository.save(sticker);
+        }
+    }
+    
+}


### PR DESCRIPTION
**프론트 요청 사항에 따라 DB 일부 수정**

- Letters 엔티티 : Long font 를 String font 로 변경, String align 추가

- equals, haseCode, toString 메소드 재작성

<br>

**API 구현을 위해 LetterStickers 엔티티 작성**

- num, img 는 정수 (Long)

- positionX, positionY, width 는 실수 (Double)

<br>

**http://localhost:8080/api/letter/wkejgieut 로 POST 요청을 보낸 경우 테스트**

- wkejgieut 라는 blackboardId를 가진 칠판에 편지를 작성한다는 의미

- `@RequestBody` 는 다음과 같음

```json
{
    "nickname" : "편지작성자입니다.",
    "content" : "`이건 텍스트 에디터....<div>왜구현이 안되지...</div><div>진짜 마음개힘들다</div><div>왜 색깔먹이<span cLass='red'>면 엔터가 안될까</span>요?왜 색깔먹이<span class='red'>면 엔터가 안될까</span>요?왜 색깔먹이<span class='red'>면 엔터가 안될까</span>요?</div><div>왜 색깔 먹이<span class='red'>면 엔터가 안될까</span>요?왜 색깔먹이<span class='red'>면 엔터가 안될까</span>요? 왜 색깔먹이<span cLass='red'>면 엔터가 안될까</span>요?`",
    "font" : "Alien",
    "align" : "center",
    "stickers" : [
        {
            "num" : 1,
            "positionX" : 0.5,
            "positionY" : 0.3,
            "img" : 3,
            "width" : "1.5"
        },
        {
            "num" : 2,
            "positionX" : 0.7,
            "positionY" : 0.4,
            "img" : 7,
            "width" : "1.2"
        }
    ]
}
```

- 현재는 blackboardId를 임시로 넣었지만 추후에 실제 값으로 테스트

- letter와 letter_sticker 모두 잘 생성되는 것을 확인

- 연관관계도 잘 맺어짐 (letter_stickers 테이블의 FK(letter_id)가 1인 것으로 확인 가능)

<img width="694" alt="스크린샷 2023-11-06 오후 3 25 24" src="https://github.com/balckBoard-4line/blackBoard-back/assets/98332877/c2ffd092-1812-45ed-8ee8-b0096c4af5a1">

<img width="909" alt="스크린샷 2023-11-06 오후 3 26 49" src="https://github.com/balckBoard-4line/blackBoard-back/assets/98332877/a04d1070-943f-4ebe-9868-74d390213cd1">


